### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_linux.yml
+++ b/.github/workflows/main_linux.yml
@@ -14,9 +14,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build-pack-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/main_win.yml
+++ b/.github/workflows/main_win.yml
@@ -14,9 +14,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build-pack-win64:
     runs-on: windows-2022
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -10,9 +10,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build-pack-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -7,9 +7,14 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-pack-win64:
     runs-on: windows-2022
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/OSA413/Sonic4_ModLoader/security/code-scanning/9](https://github.com/OSA413/Sonic4_ModLoader/security/code-scanning/9)

In general, the fix is to define explicit `permissions:` for the workflow or per job so that the automatic GITHUB_TOKEN is granted only the scopes actually required. For jobs that only need to read the repository contents, `permissions: contents: read` is sufficient. For jobs that publish releases or otherwise modify repository resources, you should grant only the specific write scopes they need, such as `contents: write` for creating or updating releases with `softprops/action-gh-release`.

For this workflow, the best minimal fix without changing functionality is:
- Add a root-level `permissions:` block that sets `contents: read` for all jobs by default, documenting that most of the workflow only needs read access.
- Add an overriding `permissions:` block under the `build-pack-win64` job to grant `contents: write`, since `softprops/action-gh-release@v2` needs to modify release assets.
- Leave the `tests` job with the default (inherited) `contents: read` permissions, which is sufficient for `actions/checkout`, `actions/cache`, and running `cargo test`.

Concretely:
- Edit `.github/workflows/release_win.yml`.
- Insert at the top-level (between `on:` and `jobs:` or right after `on:`) a `permissions:` block with `contents: read`.
- Inside the `build-pack-win64` job definition, add a job-level `permissions:` block with `contents: write`.

No additional imports or external dependencies are required; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
